### PR TITLE
Clean up README. Remove non-rule rule. PROFIT!!!

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ## Welcome to the Magical Kingdom Poet Society
 Make a PR. Fux wit dis repo. Add things. Delete things. Screw things up so you can learn to revert them.
 
+- Edit [WeAreGo.md](docs/WeAreGo.md) checking the box next to your name to prove your karate & friendship. (**test if you can commit & push**)
 - [Helpful Links](docs/HelpfulLinks.md)
 - [VIM Stuff](docs/VIM.md)
 
@@ -13,10 +14,8 @@ Make a PR. Fux wit dis repo. Add things. Delete things. Screw things up so you c
 Hereth be yon rules:
 1. Thou shalt ask ONLY ridiculous questions, and ridiculous shall thine questions be.
 1. All Pull Requests must be accompanied by an animated gif. No exceptions.
-1. All ordered lists must use one-dot GH flavored markdown syntax
-1. three sir!
-1. Edit [WeAreGo.md](docs/WeAreGo.md) checking the box next to your name to prove your karate & friendship. (**test if you can commit & push**)
-1. All roads lead to Rome
-1. Get your hands dirty, try for thirty - After that, ask for Matt
+1. Five...no three sir!
+1. All ordered lists must use `1.` [GitHub flavored markdown](https://guides.github.com/features/mastering-markdown/) syntax. ex: `1. First Item` `1. Second Item` `1. Third Item`
+1. Get your hands dirty, try for thirty - After that, ping [Matt](https://github.com/mathisto) or [Brian](https://github.com/todtb).
 1. ????
 1. PROFIT!!!


### PR DESCRIPTION
## If this PR were a GIF, what would it be?
![Clean up. Clean up](https://media.giphy.com/media/z5fNH8BMbeDN6/giphy.gif)

## Description of change(s)
- "All roads lead to Rome" was removed from the rule list since it wasn't a rule.
- Moved "WeAreGo.md" 'rule' to the list of links. This was also not a rule.
- Rule three needed to be swapped...OBVIOUSLY.
- Rule three needed to propose five, and then suddenly, at the last moment, remember to be three.
- Added example of `1.` ordered list syntax to rule 4.
- Added a link to "Mastering Markdown" on rule 4.
- Rephrased wording on rule 5 and added links to Brian and I's GH profiles.

## Diligence checklist (omit non-applicable items):
- [x] Has Readme/Wiki/documentation been updated?
- [x] Are you a lumberjack?
- [x] Is that OK?
- [x] Is this code production ready?
